### PR TITLE
Feature/#4/meme draft

### DIFF
--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/api/MemeController.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/api/MemeController.java
@@ -1,0 +1,42 @@
+package com.yapp.memeserver.domain.meme.api;
+
+import com.yapp.memeserver.domain.meme.domain.Meme;
+import com.yapp.memeserver.domain.meme.dto.MemeListResDto;
+import com.yapp.memeserver.domain.meme.dto.MemeResDto;
+import com.yapp.memeserver.domain.meme.repository.MemeRepository;
+import com.yapp.memeserver.domain.meme.service.MemeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/memes")
+@RequiredArgsConstructor
+public class MemeController {
+
+    private final MemeService memeService;
+
+    @GetMapping()
+    @ResponseStatus(value = HttpStatus.OK)
+    public MemeListResDto readAllMemes(Pageable pageable) {
+        List<Meme> memeList = memeService.findAllPaging(pageable);
+        MemeListResDto resDto = MemeListResDto.of(memeList);
+        return resDto;
+    }
+
+    @GetMapping("/{memeId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public MemeResDto readMeme(@PathVariable final Long memeId) {
+        Meme meme = memeService.findById(memeId);
+        meme.updateViewCount();
+        MemeResDto resDto = MemeResDto.of(meme);
+        return resDto;
+    }
+
+
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Meme.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Meme.java
@@ -24,7 +24,7 @@ public class Meme {
     private String title;
 
     @NotNull(message = "이미지는 필수로 입력되어야 합니다.")
-    @Column(length = 200)
+    @Column(length = 1024)
     private String imageUrl;
 
     private Integer viewCount;
@@ -39,5 +39,9 @@ public class Meme {
     public void updateMeme(String title, String imageUrl) {
         this.title = title;
         this.imageUrl = imageUrl;
+    }
+
+    public void updateViewCount(){
+        this.viewCount += 1;
     }
 }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Meme.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Meme.java
@@ -27,11 +27,16 @@ public class Meme {
     @Column(length = 200)
     private String imageUrl;
 
-    @ColumnDefault("0")
     private Integer viewCount;
 
     @Builder
     public Meme(String title, String imageUrl) {
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.viewCount = 0;
+    }
+
+    public void updateMeme(String title, String imageUrl) {
         this.title = title;
         this.imageUrl = imageUrl;
     }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Meme.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Meme.java
@@ -1,0 +1,38 @@
+package com.yapp.memeserver.domain.meme.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Meme {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meme_id")
+    private Long id;
+
+    @NotNull(message = "제목은 필수로 입력되어야 합니다.")
+    @Column(length = 100)
+    private String title;
+
+    @NotNull(message = "이미지는 필수로 입력되어야 합니다.")
+    @Column(length = 200)
+    private String imageUrl;
+
+    @ColumnDefault("0")
+    private Integer viewCount;
+
+    @Builder
+    public Meme(String title, String imageUrl) {
+        this.title = title;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/MemeTag.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/MemeTag.java
@@ -1,0 +1,35 @@
+package com.yapp.memeserver.domain.meme.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemeTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meme_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull(message = "밈은 필수로 입력되어야 합니다.")
+    @JoinColumn(name = "meme_id", updatable = false)
+    private Meme meme;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull(message = "태그는 필수로 입력되어야 합니다.")
+    @JoinColumn(name = "tag_id", updatable = false)
+    private Tag tag;
+
+    @Builder
+    public MemeTag(Meme meme, Tag tag) {
+        this.meme = meme;
+        this.tag = tag;
+    }
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Tag.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Tag.java
@@ -1,0 +1,23 @@
+package com.yapp.memeserver.domain.meme.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long id;
+
+    @NotNull(message = "이름은 필수로 입력되어야 합니다.")
+    @Column(length = 50)
+    private String name;
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Tag.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/domain/Tag.java
@@ -1,6 +1,7 @@
 package com.yapp.memeserver.domain.meme.domain;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,13 @@ public class Tag {
     @NotNull(message = "이름은 필수로 입력되어야 합니다.")
     @Column(length = 50)
     private String name;
+
+    @Builder
+    public Tag(Long id, String name) {
+        this.name = name;
+    }
+
+    public void updateTag(String name) {
+        this.name = name;
+    }
 }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/dto/MemeListResDto.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/dto/MemeListResDto.java
@@ -1,0 +1,46 @@
+package com.yapp.memeserver.domain.meme.dto;
+
+import com.yapp.memeserver.domain.meme.domain.Meme;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemeListResDto {
+
+    private List<SingleMeme> memes;
+    private Integer count;
+
+    @Getter
+    public static class SingleMeme {
+        private Long memeId;
+        private String title;
+        private String imageUrl;
+        private Integer viewCount;
+
+        public SingleMeme(Meme meme) {
+            this.memeId = meme.getId();
+            this.title = meme.getTitle();
+            this.imageUrl = meme.getImageUrl();
+            this.viewCount = meme.getViewCount();
+        }
+
+        public static SingleMeme of(Meme meme) {
+            return new SingleMeme(meme);
+        }
+    }
+
+    public static MemeListResDto of(List<Meme> memeList) {
+        return MemeListResDto.builder()
+                .memes(memeList.stream().map(SingleMeme::of).collect(Collectors.toList()))
+                .count(memeList.size())
+                .build();
+    }
+
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/dto/MemeResDto.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/dto/MemeResDto.java
@@ -1,0 +1,28 @@
+package com.yapp.memeserver.domain.meme.dto;
+
+import com.yapp.memeserver.domain.meme.domain.Meme;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemeResDto {
+
+    private Long memeId;
+    private String title;
+    private String imageUrl;
+    private Integer viewCount;
+
+    public static MemeResDto of(Meme meme) {
+        return MemeResDto.builder()
+                .memeId(meme.getId())
+                .title(meme.getTitle())
+                .imageUrl(meme.getImageUrl())
+                .viewCount(meme.getViewCount())
+                .build();
+    }
+
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/MemeRepository.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/MemeRepository.java
@@ -1,0 +1,12 @@
+package com.yapp.memeserver.domain.meme.repository;
+
+import com.yapp.memeserver.domain.meme.domain.Meme;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemeRepository extends JpaRepository<Meme, Long> {
+
+    // 페이징 처리. 전체 밈 조회, 조회순 밈 조회에 사용
+    Page<Meme> findAll(Pageable pageable);
+}

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/service/MemeService.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/service/MemeService.java
@@ -1,0 +1,41 @@
+package com.yapp.memeserver.domain.meme.service;
+
+import com.yapp.memeserver.domain.meme.domain.Meme;
+import com.yapp.memeserver.domain.meme.domain.Tag;
+import com.yapp.memeserver.domain.meme.dto.MemeListResDto;
+import com.yapp.memeserver.domain.meme.repository.MemeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemeService {
+
+    private final MemeRepository memeRepository;
+
+    @Transactional(readOnly = true)
+    public Meme findById(Long memeId) {
+        return memeRepository.findById(memeId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 id를 가진 Meme을 찾을 수 없습니다. id = "+ memeId ));
+    }
+
+    public List<Meme> findAllPaging(Pageable pageable) {
+        Page<Meme> memePage = memeRepository.findAll(pageable);
+        List<Meme> memeList = new ArrayList<Meme>();
+
+        if(memePage!=null && memePage.hasContent()){
+            memeList = memePage.getContent();
+        }
+        return memeList;
+    }
+}

--- a/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/MemeTagTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/MemeTagTest.java
@@ -1,0 +1,41 @@
+package com.yapp.memeserver.domain.meme.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemeTagTest {
+    @Test
+    void 밈_생성_테스트() {
+        String title = "밈 제목";
+        String imageUrl = "https://user-images.githubusercontent.com/62461857/201794604-7f9f6389-1bc9-44e2-8dbb-eb7b1fd3c513.png";
+        String name = "태그명";
+
+        Meme meme = createMeme(title, imageUrl);
+        Tag tag = createTag(name);
+        MemeTag memeTag = createMemeTag(meme, tag);
+
+        assertThat(memeTag.getMeme()).isEqualTo(meme);
+        assertThat(memeTag.getTag()).isEqualTo(tag);
+    }
+
+    private MemeTag createMemeTag(Meme meme, Tag tag) {
+        return MemeTag.builder()
+                .meme(meme)
+                .tag(tag)
+                .build();
+    }
+
+    private Meme createMeme(String title, String imageUrl) {
+        return Meme.builder()
+                .title(title)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+    private Tag createTag(String name) {
+        return Tag.builder()
+                .name(name)
+                .build();
+    }
+}

--- a/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/MemeTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/MemeTest.java
@@ -32,6 +32,21 @@ class MemeTest {
         assertThat(meme.getImageUrl()).isEqualTo(newImageUrl);
     }
 
+    @Test
+    void 밈_조회수_증가_테스트() {
+        String title = "밈 제목";
+        String imageUrl = "https://user-images.githubusercontent.com/62461857/201794604-7f9f6389-1bc9-44e2-8dbb-eb7b1fd3c513.png";
+
+        Meme meme = createMeme(title, imageUrl);
+        for (int i = 0; i < 10; i++) {
+            meme.updateViewCount();
+        }
+
+        assertThat(meme.getTitle()).isEqualTo(title);
+        assertThat(meme.getImageUrl()).isEqualTo(imageUrl);
+        assertThat(meme.getViewCount()).isEqualTo(10);
+    }
+
     private Meme createMeme(String title, String imageUrl) {
         return Meme.builder()
                 .title(title)

--- a/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/MemeTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/MemeTest.java
@@ -1,0 +1,41 @@
+package com.yapp.memeserver.domain.meme.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemeTest {
+
+    @Test
+    void 밈_생성_테스트() {
+        String title = "밈 제목";
+        String imageUrl = "https://user-images.githubusercontent.com/62461857/201794604-7f9f6389-1bc9-44e2-8dbb-eb7b1fd3c513.png";
+
+        Meme meme = createMeme(title, imageUrl);
+
+        assertThat(meme.getTitle()).isEqualTo(title);
+        assertThat(meme.getImageUrl()).isEqualTo(imageUrl);
+        assertThat(meme.getViewCount()).isEqualTo(0);
+    }
+
+    @Test
+    void 밈_수정_테스트() {
+        String title = "밈 제목";
+        String imageUrl = "https://user-images.githubusercontent.com/62461857/201794604-7f9f6389-1bc9-44e2-8dbb-eb7b1fd3c513.png";
+        String newTitle = "새 밈 제목";
+        String newImageUrl = "https://user-images.githubusercontent.com/62461857/201794714-a8e7ed02-f327-4c8b-840f-afce02805759.png";
+
+        Meme meme = createMeme(title, imageUrl);
+        meme.updateMeme(newTitle, newImageUrl);
+
+        assertThat(meme.getTitle()).isEqualTo(newTitle);
+        assertThat(meme.getImageUrl()).isEqualTo(newImageUrl);
+    }
+
+    private Meme createMeme(String title, String imageUrl) {
+        return Meme.builder()
+                .title(title)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/TagTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/domain/meme/domain/TagTest.java
@@ -1,0 +1,34 @@
+package com.yapp.memeserver.domain.meme.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TagTest {
+
+    @Test
+    void 태그_생성_테스트() {
+        String name = "태그명";
+
+        Tag tag = createTag(name);
+
+        assertThat(tag.getName()).isEqualTo(name);
+    }
+
+    @Test
+    void 태그_수정_테스트() {
+        String name = "태그명";
+        String newName = "새 태그명";
+
+        Tag tag = createTag(name);
+        tag.updateTag(newName);
+
+        assertThat(tag.getName()).isEqualTo(newName);
+    }
+
+    private Tag createTag(String name) {
+        return Tag.builder()
+                .name(name)
+                .build();
+    }
+}

--- a/spring/src/test/java/com/yapp/memeserver/domain/meme/repository/MemeRepositoryTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/domain/meme/repository/MemeRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.yapp.memeserver.domain.meme.repository;
+
+import com.yapp.memeserver.domain.meme.domain.Meme;
+import com.yapp.memeserver.global.test.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemeRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private MemeRepository memeRepository;
+
+    private Meme meme1;
+    private Meme meme2;
+    private Meme meme3;
+
+
+    @BeforeEach
+    public void setUp() {
+        meme1 = createMeme("밈1", "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t");
+        meme2 = createMeme("밈2", "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t");
+        meme3 = createMeme("밈3", "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t");
+    }
+
+    @Test
+    public void findAllPagingTest() {
+        int newViewCount1 = 4;
+        int newViewCount2 = 9;
+        int newViewCount3 = 1;
+        changeViewCount(meme1, newViewCount1);
+        changeViewCount(meme2, newViewCount2);
+        changeViewCount(meme3, newViewCount3);
+        Pageable pageable = PageRequest.of(0, 5, Sort.Direction.DESC, "viewCount");
+
+        Page<Meme> result = memeRepository.findAll(pageable);
+
+        // 총 몇 페이지
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        // 전체 개수
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        // 현재 페이지 번호 0부터 시작
+        assertThat(result.getNumber()).isEqualTo(0);
+        // 페이지당 데이터 개수
+        assertThat(result.getSize()).isEqualTo(5);
+        // 다음 페이지 존재 여부
+        assertThat(result.hasNext()).isEqualTo(false);
+        // 시작 페이지(0) 여부
+        assertThat(result.isFirst()).isEqualTo(true);
+
+        for (Meme meme : result.getContent()) {
+            System.out.println("meme.getViewCount() = " + meme.getViewCount());
+        }
+
+    }
+
+
+    private Meme createMeme(String title, String imageUrl) {
+        Meme meme = Meme.builder()
+                .title(title)
+                .imageUrl(imageUrl)
+                .build();
+        return memeRepository.save(meme);
+    }
+
+    private void changeViewCount(Meme meme, int newViewCount) {
+        for (int i = 0; i < newViewCount; i++) {
+            meme.updateViewCount();
+        }
+    }
+
+
+
+}

--- a/spring/src/test/java/com/yapp/memeserver/global/test/RepositoryTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/global/test/RepositoryTest.java
@@ -1,0 +1,26 @@
+package com.yapp.memeserver.global.test;
+
+import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
+import com.github.gavlyukovskiy.boot.jdbc.decorator.p6spy.P6SpyConfiguration;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+// Spring extension을 등록
+@DataJpaTest()
+// Repository에 대한 Bean만 등록. showSql false를 통해 Spring Data JPA가 기본적으로 제공해주는 SQL 문 츨력 X
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// application.yml의 DB 설정과 연결한다. 기존 값 Replace.ANY 는 테스트용 인메모리를 강제로 사용한다는 의미
+@ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
+// 자동 환경 설정 클래스를 import한다. 내부의 클래스는 application.yml 에서 사용하고 있는 DataSource 를, 프록시한 객체로 만들어주는 역할을 한다.
+@Disabled
+// 테스트 비활성화
+//@Import(P6SpyConfiguration.class)
+// 직접 커스텀한 p6spy 세팅을 import 시켜준다.
+public class RepositoryTest {
+}


### PR DESCRIPTION
## 작업내용
- Meme 엔티티 관련 초안 작성했습니다.
    - Meme, Tag, MemeTag 엔티티 추가 및 테스트 코드 작성
    - MemeRepository 추가 및 테스트 코드 작성
    - MemeService 추가
    - MemeController 추가
    - MemeListResDto, MemeResDto 추가

### 작성 API

#### 테스트용 초기 데이터
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/62461857/205426703-25b321a5-e36a-432e-9e27-188234ed79e4.png">

#### 특정 Meme 조회
`http://127.0.0.1:8080/memes/1`
``` json
{"memeId":1,"title":"안녕1","imageUrl":"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t","viewCount":2}
```
#### 여러 Meme 조회
`http://127.0.0.1:8080/memes`
``` json
{"memes":[{"memeId":1,"title":"안녕1","imageUrl":"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t","viewCount":1},{"memeId":2,"title":"안녕9","imageUrl":"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t","viewCount":9},{"memeId":3,"title":"안녕5","imageUrl":"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t","viewCount":5}],"count":3}
```
#### 페이징 및 정렬 설정 (0번째 페이지, 2개씩, viewCount 기준으로, 내림차순 정렬)
`http://127.0.0.1:8080/memes?page=0&size=2&sort=viewCount,desc`
``` json
{"memes":[{"memeId":2,"title":"안녕9","imageUrl":"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t","viewCount":9},{"memeId":3,"title":"안녕5","imageUrl":"https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t","viewCount":5}],"count":2}
```

## 참고사항
- 서비스, 컨트롤러, DTO 테스트 코드는 확인할만한 내부 로직도 엔티티와 레포지토리에 의존적이고, 시간도 없어 작성하지 않았습니다. 추후에 작성하겠습니다. 
- Postman으로 테스트는 했습니다.
- 테스트 코드는 추후 작성하도록 하겠습니다.

Closes #4
