### PR TITLE
Feature/#14/tag auto complete

### DIFF
--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/api/TagController.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/api/TagController.java
@@ -34,11 +34,18 @@ public class TagController {
 
     @GetMapping("/{tagId}")
     @ResponseStatus(value = HttpStatus.OK)
-    public TagResDto readMeme(@PathVariable final Long tagId) {
+    public TagResDto readTag(@PathVariable final Long tagId) {
         tagService.read(tagId);
         Tag tag = tagService.findById(tagId);
         TagResDto resDto = TagResDto.of(tag);
         return resDto;
     }
 
+    @GetMapping("/search")
+    @ResponseStatus(value = HttpStatus.OK)
+    public TagListResDto searchTag(@RequestParam String word) {
+        List<Tag> tagList = tagService.findByNameContains(word);
+        TagListResDto resDto = TagListResDto.of(tagList);
+        return resDto;
+    }
 }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/TagRepository.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/TagRepository.java
@@ -17,7 +17,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     // 페이징 처리. 전체 밈 조회, 조회순 밈 조회에 사용
     Page<Tag> findAll(Pageable pageable);
     List<Tag> findByCategory(Category category);
-    List<Tag> findByNameContains(String word);
+    List<Tag> findByNameContainsOrderByViewCountDesc(String word);
 
     // 조회수 증가 코드. ModifiedDate를 변경시키지 않기 위함.
     @Modifying(clearAutomatically = true) // 연산 이후 영속성 컨텍스트를 clear 하도록 설정

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/TagRepository.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/TagRepository.java
@@ -17,6 +17,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     // 페이징 처리. 전체 밈 조회, 조회순 밈 조회에 사용
     Page<Tag> findAll(Pageable pageable);
     List<Tag> findByCategory(Category category);
+    List<Tag> findByNameContains(String word);
 
     // 조회수 증가 코드. ModifiedDate를 변경시키지 않기 위함.
     @Modifying(clearAutomatically = true) // 연산 이후 영속성 컨텍스트를 clear 하도록 설정

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/service/TagService.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/service/TagService.java
@@ -50,7 +50,7 @@ public class TagService {
 
     @Transactional(readOnly = true)
     public List<Tag> findByNameContains(String word) {
-        List<Tag> tagList = tagRepository.findByNameContains(word);
+        List<Tag> tagList = tagRepository.findByNameContainsOrderByViewCountDesc(word);
         return tagList;
     }
 

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/service/TagService.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/service/TagService.java
@@ -37,6 +37,7 @@ public class TagService {
         return tagRepository.findByCategory(category);
     }
 
+    @Transactional(readOnly = true)
     public List<Tag> findAllPaging(Pageable pageable) {
         Page<Tag> tagPage = tagRepository.findAll(pageable);
         List<Tag> tagList = new ArrayList<Tag>();
@@ -44,6 +45,12 @@ public class TagService {
         if(tagPage!=null && tagPage.hasContent()){
             tagList = tagPage.getContent();
         }
+        return tagList;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Tag> findByNameContains(String word) {
+        List<Tag> tagList = tagRepository.findByNameContains(word);
         return tagList;
     }
 


### PR DESCRIPTION
## 작업내용
- 태그 자동완성 기능
- 결과를 조회순으로 정렬
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62461857/205456107-3ef10844-4792-4ba3-9442-d43491c4e3d9.png">

### API
`http://127.0.0.1:8080/tags/search?word=태그`
``` json
{"tags":[{"tagId":3,"name":"태그 제목3","categoryId":2,"categoryName":"카테고리 명2","viewCount":14},{"tagId":5,"name":"태그 제목5","categoryId":1,"categoryName":"카테고리 명1","viewCount":11},{"tagId":2,"name":"태그 제목2","categoryId":2,"categoryName":"카테고리 명2","viewCount":10},{"tagId":4,"name":"태그 제목4","categoryId":1,"categoryName":"카테고리 명1","viewCount":6},{"tagId":1,"name":"태그 제목1","categoryId":1,"categoryName":"카테고리 명1","viewCount":1}],"count":5}
```
## 참고사항
- 포함된 모든 태그가 조회순으로 반환됩니다. 

Closes #14
