### PR TITLE
Feature/YW-87/set docker

### DIFF
--- a/spring/.gitignore
+++ b/spring/.gitignore
@@ -39,3 +39,7 @@ out/
 
 ## 환경변수 파일
 application-oauth2.yml
+config/
+
+## Docker Volume
+data/

--- a/spring/Dockerfile
+++ b/spring/Dockerfile
@@ -1,0 +1,13 @@
+# 11버전에서는 alpine을 아직 지원하지 않는다.
+FROM adoptopenjdk/openjdk11
+
+# /usr/src/app/ 을 컨테이너 작업 기본 디렉터리로 설정한다.
+ENV APP_HOME=/usr/src/app/
+WORKDIR $APP_HOME
+
+# 생성된 jar 파일을 /usr/src/app/app.jar 로 옮긴다
+ARG JAR_FILE_PATH=build/libs/*.jar
+COPY ${JAR_FILE_PATH} ./app.jar
+
+# app.jar 파일을 실행한다.
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","./app.jar"]

--- a/spring/docker-compose.yml
+++ b/spring/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - "--collation-server=utf8mb4_unicode_ci"
     env_file:
       - ./config/mysql.env
+    volumes:
+      - ./data/db:/var/lib/mysql
 
   cache_redis:
     image: redis:alpine

--- a/spring/docker-compose.yml
+++ b/spring/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "--collation-server=utf8mb4_unicode_ci"
     env_file:
       - ./config/mysql.env
+      - ./config/tz.env
     volumes:
       - ./data/db:/var/lib/mysql
 
@@ -20,6 +21,7 @@ services:
       - "6379:6379"
     env_file:
       - ./config/redis.env
+      - ./config/tz.env
     volumes:
       - ./data/cache:/data
     command:
@@ -35,5 +37,7 @@ services:
     env_file:
       - ./config/mysql.env
       - ./config/redis.env
+      - ./config/tz.env
     depends_on:
       - db_mysql
+      - cache_redis

--- a/spring/docker-compose.yml
+++ b/spring/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+
+  db_mysql:
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    command:
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"
+    env_file:
+      - ./config/mysql.env
+
+  cache_redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    env_file:
+      - ./config/redis.env
+    volumes:
+      - ./data/cache:/data
+    command:
+      - /bin/sh
+      - -c
+      - redis-server --requirepass "$${REDIS_PASSWORD}"
+
+  app_spring:
+    build: .
+    ports:
+      - "8080:8080"
+    restart: on-failure
+    env_file:
+      - ./config/mysql.env
+      - ./config/redis.env
+    depends_on:
+      - db_mysql

--- a/spring/docker-compose.yml
+++ b/spring/docker-compose.yml
@@ -4,8 +4,9 @@ services:
 
   db_mysql:
     image: mysql:8
+    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부). 필자는 로컬 MySQL 3306과 겹치지 않도록 3307으로 선택
     ports:
-      - "3306:3306"
+      - "3307:3306"
     command:
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"

--- a/spring/src/main/resources/application-dev.yml
+++ b/spring/src/main/resources/application-dev.yml
@@ -1,0 +1,50 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://db_mysql:3306/${MYSQL_DATABASE}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+
+  jpa:
+    database: mysql
+    hibernate:
+      # 자동으로 테이블을 만들어주는 모드. create로 두면 애플리케이션 실행 시점에 테이블을 drop 하고, 다시 생성한다.
+      ddl-auto: create
+      properties:
+        hibernate:
+          dialect: org.hibernate.dialect.Mysql8Dialect
+    defer-datasource-initialization: true
+
+  redis:
+    host: cache_redis
+    port: 6379
+    password: ${REDIS_PASSWORD}
+
+  sql:
+    init:
+      mode: never
+      data-locations: classpath:sql/data.sql
+      schema-locations: classpath:sql/schema.sql
+
+# Actuator 설정
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - "health"
+      base-path: "/system"
+  endpoint:
+    health:
+      enabled: true
+      show-details: always
+
+# p6spy 적용
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/spring/src/main/resources/application-test.yml
+++ b/spring/src/main/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
   h2:
     console:
       enabled: true
+      settings:
+        web-allow-others: true
 
   jpa:
     hibernate:

--- a/spring/src/main/resources/application-test.yml
+++ b/spring/src/main/resources/application-test.yml
@@ -28,7 +28,7 @@ spring:
 
   sql:
     init:
-      mode: always
+      mode: never
       data-locations: classpath:sql/data.sql
 
   redis:

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 spring:
   profiles:
     default:
-      - test
+      - dev
       - oauth2

--- a/spring/src/test/java/com/yapp/memeserver/domain/meme/repository/MemeRepositoryTest.java
+++ b/spring/src/test/java/com/yapp/memeserver/domain/meme/repository/MemeRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.annotation.DirtiesContext.MethodMode.BEFORE_METHOD;
 
 class MemeRepositoryTest extends RepositoryTest {
@@ -32,7 +31,6 @@ class MemeRepositoryTest extends RepositoryTest {
         meme3 = createMeme("밈3", "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/cad31965-0c62-44ca-ae45-4e050d4ec9b8t");
     }
 
-    @DirtiesContext(methodMode = BEFORE_METHOD)
     @Test
     public void findAllPagingTest() {
         int newViewCount1 = 4;
@@ -44,6 +42,10 @@ class MemeRepositoryTest extends RepositoryTest {
         Pageable pageable = PageRequest.of(0, 5, Sort.Direction.DESC, "viewCount");
 
         Page<Meme> result = memeRepository.findAll(pageable);
+
+        for (Meme meme : result.getContent()) {
+            System.out.println("meme.getViewCount() = " + meme.getViewCount());
+        }
 
         // 총 몇 페이지
         assertThat(result.getTotalPages()).isEqualTo(1);
@@ -57,10 +59,6 @@ class MemeRepositoryTest extends RepositoryTest {
         assertThat(result.hasNext()).isEqualTo(false);
         // 시작 페이지(0) 여부
         assertThat(result.isFirst()).isEqualTo(true);
-
-        for (Meme meme : result.getContent()) {
-            System.out.println("meme.getViewCount() = " + meme.getViewCount());
-        }
 
     }
 

--- a/spring/src/test/resources/application.yml
+++ b/spring/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  profiles:
+    default:
+      - test
+      - oauth2


### PR DESCRIPTION
## 작업내용
- Docker 설정
- EC2 Dev 서버에서 사용할 Docker Compose 설정
    - DB, Redis, Spring 을 한 EC2에 둘 예정
    - application.dev.yml 설정
    - config를 통해 환경변수를 주입 받아, Redis, DB 세팅
    - DB TZ 서울로 세팅
- gradlew build 통과를 위한 test의 application.yml 디폴트 설정
- 추후에 데이터를 채워 둬야 하므로, 볼륨 설정
- 볼륨 및 환경변수 파일들 gitignore 설정
## 참고사항
- gitignore 가 추가되었습니다.
- 도커 컨테이너 외부로 공개되는 DB Port를 3307로 설정하였습니다.

### 참고 링크
- Jira Issue : [YW-87](https://yapp21-web1.atlassian.net/browse/YW-87)    
- Github Issue : #24
