### PR TITLE
Feature/YW-113]/auth draft

### DIFF
--- a/spring/.gitignore
+++ b/spring/.gitignore
@@ -39,7 +39,7 @@ out/
 
 ## 환경변수 파일
 application-oauth2.yml
-./config/
+config/
 
 ## Docker Volume
 data/

--- a/spring/.gitignore
+++ b/spring/.gitignore
@@ -39,7 +39,7 @@ out/
 
 ## 환경변수 파일
 application-oauth2.yml
-config/
+./config/
 
 ## Docker Volume
 data/

--- a/spring/docker-compose.yml
+++ b/spring/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     # 접근 포트 설정 (컨테이너 외부:컨테이너 내부). 필자는 로컬 MySQL 3306과 겹치지 않도록 3307으로 선택
     ports:
       - "3307:3306"
+    restart: on-failure
     command:
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"

--- a/spring/src/main/java/com/yapp/memeserver/domain/auth/dto/OAuthAttributes.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/auth/dto/OAuthAttributes.java
@@ -33,7 +33,8 @@ public class OAuthAttributes {
         return ofKakao("id", attributes);
     }
 
-    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+    // OAuth2AuthenticationSuccessHandler 에서 가져오기 위해 public 으로 설정
+    public static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
         // kakao는 kakao_account에 유저정보가 있다. (email)
         Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
         // kakao_account안에 또 profile이라는 JSON객체가 있다. (nickname, profile_image)

--- a/spring/src/main/java/com/yapp/memeserver/domain/auth/service/CustomOAuth2UserService.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/auth/service/CustomOAuth2UserService.java
@@ -3,11 +3,9 @@ package com.yapp.memeserver.domain.auth.service;
 
 import com.yapp.memeserver.domain.account.domain.Account;
 import com.yapp.memeserver.domain.account.repository.AccountRepository;
-import com.yapp.memeserver.domain.account.service.AccountService;
 import com.yapp.memeserver.domain.auth.dto.OAuthAttributes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;

--- a/spring/src/main/java/com/yapp/memeserver/domain/auth/service/OAuth2AuthenticationSuccessHandler.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/auth/service/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,46 @@
+package com.yapp.memeserver.domain.auth.service;
+
+import com.yapp.memeserver.domain.account.domain.Account;
+import com.yapp.memeserver.domain.auth.dto.OAuthAttributes;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
+        OAuthAttributes attributes = OAuthAttributes.ofKakao("id", principal.getAttributes());
+        String url = makeRedirectUrl(attributes.getName(), attributes.getEmail());
+
+        if (response.isCommitted()) {
+            logger.debug("응답이 이미 커밋된 상태입니다. " + url + "로 리다이렉트하도록 바꿀 수 없습니다.");
+            return;
+        }
+
+        getRedirectStrategy().sendRedirect(request, response, url);
+    }
+
+    // UTF-8로 인코딩 해서 반환. name과 email을 인자로 넣는다.
+    private String makeRedirectUrl(String name, String email) {
+        return UriComponentsBuilder.fromHttpUrl("http://localhost:3000/oauth2/redirect")
+                .queryParam("name", name)
+                .queryParam("email", email)
+                .build()
+                .encode()
+                .toUriString();
+    }
+}

--- a/spring/src/main/java/com/yapp/memeserver/global/config/SecurityConfig.java
+++ b/spring/src/main/java/com/yapp/memeserver/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.yapp.memeserver.global.config;
 
 import com.yapp.memeserver.domain.auth.service.CustomOAuth2UserService;
+import com.yapp.memeserver.domain.auth.service.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
     // Spring Security에서 제공하는 비밀번호 암호화 클래스.
     // Service에서 사용할 수 있도록 Bean으로 등록한다.
@@ -37,7 +39,9 @@ public class SecurityConfig {
                 .oauth2Login() // oauth2 로그인 시작점
                 .userInfoEndpoint() // 로그인 성공하면 사용자 정보 가져올 때 설정을 담당
                 // oauth2 로그인에 성공하면, 유저 데이터를 가지고 아래 Service에서 처리하겠다.
-                .userService(customOAuth2UserService);
+                .userService(customOAuth2UserService)
+                .and()
+                .successHandler(oAuth2AuthenticationSuccessHandler);
 
         return http.build();
     }

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    default: local
+    default: dev
     group:
       # H2 인메모리를 DB로 사용
       test:
@@ -11,6 +11,6 @@ spring:
         - common
         - oauth2
       # Docker 내부의 MySQL을 DB로 사용
-      prod:
+      dev:
         - common
         - oauth2


### PR DESCRIPTION
## 작업내용
- 카카오 OAuth 를 통해 가입 및 로그인했을 때, 해당 유저에 대한 정보를 볼 수 있도록 API 제작

#### 사용 방법
1. http://13.124.200.247:8080/oauth2/authorization/kakao 접속
2. 카카오 로그인 진행
3. 회원이 없는 경우 가입, 회원이 있는 경우 이름 이메일 업데이트 후 로그인
4. http://localhost:3000/oauth2/redirect?name=이름&email=test@gmail.com 형식으로 redirect 됨
5. 프론트엔드에서는 name과 email 을 가져와서 쿠키 및 로컬 스토리지에 저장

## 참고사항
- 추후에는 프론트엔드에서 Kakao OAuth를 진행해서 Access Token을 가져오고, 서버는 해당 토큰을 받아 회원 정보 인가 작업을 거친 후에 JWT로 반환하는 방식을 채택할 것입니다.

### 참고 링크
- Jira Issue : [YW-113](https://yapp21-web1.atlassian.net/browse/YW-113)    
- Github Issue : #29
