### PR TITLE
Feature/yw 191/rel memes

### DIFF
--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/api/MemeController.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/api/MemeController.java
@@ -63,4 +63,17 @@ public class MemeController {
         MemeListResDto resDto = MemeListResDto.of(memeList);
         return resDto;
     }
+
+    @GetMapping("/{memeId}/rel")
+    @ResponseStatus(value = HttpStatus.OK)
+    public MemeListResDto readRelMemes(@PathVariable final Long memeId, Pageable pageable) {
+        memeService.read(memeId);
+        Meme meme = memeService.findById(memeId);
+        List<MemeTag> memeTagList = memeTagService.findByMeme(meme);
+        List<Long> tagIdList = memeTagService.findTagIdList(memeTagList);
+        Page<MemeTag> memeTagPage = memeTagService.findByRelTagPaging(memeId, tagIdList, pageable);
+        List<Meme> memeList = memeTagService.findMemeTagList(memeTagPage);
+        MemeListResDto resDto = MemeListResDto.of(memeList);
+        return resDto;
+    }
 }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/MemeTagRepository.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/MemeTagRepository.java
@@ -6,6 +6,8 @@ import com.yapp.memeserver.domain.meme.domain.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +15,12 @@ public interface MemeTagRepository extends JpaRepository<MemeTag, Long> {
 
     List<MemeTag> findByMeme(Meme meme);
     Page<MemeTag> findByTag(Tag tag, Pageable pageable);
+
+    @Query(nativeQuery = true,
+            value = "select mt.meme_id, meme_tag_id, mt.tag_id from (SELECT DISTINCT MEME_ID, MEME_TAG_ID, TAG_ID FROM MEME_TAG where meme_id <> :memeId) mt join (" +
+                    "select tag_id tagId from tag t join category c on t.category_id = c.category_id where tag_id in :tagIdList order by c.priority) ts " +
+                    "on mt.tag_id = ts.tagId ",
+            countQuery = "select count(*) from (SELECT DISTINCT MEME_ID, MEME_TAG_ID, TAG_ID FROM MEME_TAG where meme_id <> :memeId) mt join (" +
+                         "select tag_id tagId from tag t  join category c on t.category_id = c.category_id where tag_id in :tagIdList) ts")
+    Page<MemeTag> findByRelTag(@Param("memeId") Long memeId, @Param("tagIdList") List<Long> tagIdList, Pageable pageable);
 }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/MemeTagRepository.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/repository/MemeTagRepository.java
@@ -18,9 +18,9 @@ public interface MemeTagRepository extends JpaRepository<MemeTag, Long> {
 
     @Query(nativeQuery = true,
             value = "select mt.meme_id, meme_tag_id, mt.tag_id from (SELECT DISTINCT MEME_ID, MEME_TAG_ID, TAG_ID FROM MEME_TAG where meme_id <> :memeId) mt join (" +
-                    "select tag_id tagId from tag t join category c on t.category_id = c.category_id where tag_id in :tagIdList order by c.priority) ts " +
+                    "select tag_id tagId from TAG t join CATEGORY c on t.category_id = c.category_id where tag_id in :tagIdList order by c.priority) ts " +
                     "on mt.tag_id = ts.tagId ",
             countQuery = "select count(*) from (SELECT DISTINCT MEME_ID, MEME_TAG_ID, TAG_ID FROM MEME_TAG where meme_id <> :memeId) mt join (" +
-                         "select tag_id tagId from tag t  join category c on t.category_id = c.category_id where tag_id in :tagIdList) ts")
+                         "select tag_id tagId from TAG t  join CATEGORY c on t.category_id = c.category_id where tag_id in :tagIdList) ts")
     Page<MemeTag> findByRelTag(@Param("memeId") Long memeId, @Param("tagIdList") List<Long> tagIdList, Pageable pageable);
 }

--- a/spring/src/main/java/com/yapp/memeserver/domain/meme/service/MemeTagService.java
+++ b/spring/src/main/java/com/yapp/memeserver/domain/meme/service/MemeTagService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,9 +34,22 @@ public class MemeTagService {
     }
 
     @Transactional(readOnly = true)
+    public Page<MemeTag> findByRelTagPaging(Long memeId, List<Long> tagIdList, Pageable pageable) {
+        return memeTagRepository.findByRelTag(memeId, tagIdList, pageable);
+    }
+
+
+    @Transactional(readOnly = true)
     public List<Tag> findTagMemeList(List<MemeTag> memeTagList) {
         return memeTagList.stream()
                 .map(MemeTag::getTag)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findTagIdList(List<MemeTag> memeTagList) {
+        return memeTagList.stream()
+                .map(m -> m.getTag().getId())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 작업내용
- 연관밈 리스트 네이티브 쿼리 작성
  - 해당 밈의 태그들 가져오기
  - 태그들을 카테고리 우선순위 순으로 정렬
  - 각 태그들의 밈들을 가져오기
  - 현재 맘과 같은 밈은 제거, 중복 밈 제거
<img width="958" alt="image" src="https://user-images.githubusercontent.com/62461857/224489525-6bbdd750-06f6-4c14-b7a4-cea4bb0b72e5.png">

## 참고사항
- 배포 서버 반영 완료
- 추후 기획이 변경되면 연관밈 로직 개선할 것

### 참고 링크
- Jira Issue : [YW-191](https://yapp21-web1.atlassian.net/browse/YW-191)    
- Github Issue : #82 


[YW-191]: https://yapp21-web1.atlassian.net/browse/YW-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ